### PR TITLE
Avoid server listen during tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "build": "vite build",
     "lint": "eslint . --ext .js,.jsx",
     "preview": "vite preview",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test": "NODE_ENV=test jest",
+    "test:watch": "NODE_ENV=test jest --watch",
+    "test:coverage": "NODE_ENV=test jest --coverage"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/server.js
+++ b/server.js
@@ -343,7 +343,7 @@ app.post('/api/assemble-video', videoGenerationLimiter, authenticateToken, check
 })
 
 // Only listen if not in serverless environment
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   app.listen(PORT, () => {
     console.log(`✨ AI Video Creator API running on http://localhost:${PORT}`)
   })


### PR DESCRIPTION
## Summary
- prevent express server from starting when NODE_ENV is test
- run jest with NODE_ENV=test so server listeners aren't triggered in tests

## Testing
- `npm test` *(fails: The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables)*

------
https://chatgpt.com/codex/tasks/task_b_688e4a763adc832593b1756cc5290ae1