### PR TITLE
Require JWT secret configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 4445",
-    "server": "PORT=4444 node server.js",
+    "server": "JWT_SECRET=dev-secret-key PORT=4444 node server.js",
     "dev:all": "concurrently \"npm run dev\" \"npm run server\"",
     "build": "vite build",
     "lint": "eslint . --ext .js,.jsx",

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -3,7 +3,10 @@ import jwt from 'jsonwebtoken'
 
 class AuthService {
   constructor() {
-    this.jwtSecret = process.env.JWT_SECRET || 'your-secret-key-change-in-production'
+    this.jwtSecret = process.env.JWT_SECRET
+    if (!this.jwtSecret) {
+      throw new Error('JWT_SECRET environment variable is required')
+    }
     this.jwtExpiry = '7d'
     this.saltRounds = 10
   }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -7,35 +7,39 @@ global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder
 
 // Mock framer-motion for tests
-jest.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }) => {
-      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
-      return React.createElement('div', rest, children)
+jest.mock('framer-motion', () => {
+  const React = require('react')
+  return {
+    motion: {
+      div: ({ children, ...props }) => {
+        const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+        return React.createElement('div', rest, children)
+      },
+      button: ({ children, ...props }) => {
+        const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+        return React.createElement('button', rest, children)
+      },
+      header: ({ children, ...props }) => {
+        const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+        return React.createElement('header', rest, children)
+      },
+      span: ({ children, ...props }) => {
+        const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+        return React.createElement('span', rest, children)
+      }
     },
-    button: ({ children, ...props }) => {
-      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
-      return React.createElement('button', rest, children)
-    },
-    header: ({ children, ...props }) => {
-      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
-      return React.createElement('header', rest, children)
-    },
-    span: ({ children, ...props }) => {
-      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
-      return React.createElement('span', rest, children)
-    }
-  },
-  AnimatePresence: ({ children }) => children,
-  useMotionValue: () => ({ set: jest.fn() }),
-  useTransform: () => 0,
-}))
+    AnimatePresence: ({ children }) => children,
+    useMotionValue: () => ({ set: jest.fn() }),
+    useTransform: () => 0,
+  }
+})
 
 // Mock environment variables
 process.env = {
   ...process.env,
   NODE_ENV: 'test',
   VITE_API_URL: 'http://localhost:3003',
+  JWT_SECRET: 'test-secret-key',
 }
 
 // Suppress console errors during tests unless explicitly testing error handling


### PR DESCRIPTION
## Summary
- require JWT_SECRET in AuthService and fail fast if missing
- add JWT_SECRET to Jest setup and fix framer-motion mock scope
- run server with a preset JWT secret for development

## Testing
- `npm test` *(fails: 3 failed, 1 passed)*
- `npm run lint` *(fails: 158 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_b_688e4a8fc79c832584f99b615f5cf1ae