### PR TITLE
feat: add postgres persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ Server sessions are stored in PostgreSQL using `connect-pg-simple`. Set
 session table is created automatically on startup, or you can create it
 manually using the SQL in [`docs/SESSION_TABLE_SETUP.md`](docs/SESSION_TABLE_SETUP.md).
 
+## 🗄️ Database Setup
+
+The application now stores user data in PostgreSQL. To configure the database:
+
+1. **Create a database** and update `DATABASE_URL` in your `.env` file. See `.env.example` for the format.
+2. **Run migrations** to create the required tables:
+
+   ```bash
+   npm run migrate
+   ```
+
+   This executes all SQL files in the `migrations/` directory.
+
 ## 🎨 UI/UX Features
 
 - **Dark Glassmorphic Design**: Modern, premium aesthetic

--- a/migrations/001_create_users_table.sql
+++ b/migrations/001_create_users_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  password TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  subscription TEXT NOT NULL DEFAULT 'free',
+  videos_created INTEGER NOT NULL DEFAULT 0,
+  monthly_limit INTEGER NOT NULL DEFAULT 3
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "^12.23.12",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.536.0",
+        "pg": "^8.13.0",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch",
-    "test:coverage": "NODE_ENV=test jest --coverage"
+    "test:coverage": "NODE_ENV=test jest --coverage",
+    "migrate": "node scripts/migrate.js"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -27,6 +28,7 @@
     "express-rate-limit": "^8.0.1",
     "express-session": "^1.18.2",
     "framer-motion": "^12.23.12",
+    "pg": "^8.13.0",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.536.0",
     "postcss": "^8.5.6",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,27 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import db from '../src/db.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+async function run() {
+  const dir = path.join(__dirname, '..', 'migrations')
+  const files = fs.readdirSync(dir).sort()
+
+  for (const file of files) {
+    const filePath = path.join(dir, file)
+    const sql = fs.readFileSync(filePath, 'utf8')
+    console.log(`Running migration ${file}`)
+    await db.query(sql)
+  }
+
+  await db.end()
+  console.log('Migrations completed')
+}
+
+run().catch(err => {
+  console.error('Migration failed', err)
+  process.exit(1)
+})

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,13 @@
+import pkg from 'pg'
+
+const { Pool } = pkg
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined
+})
+
+export default {
+  query: (text, params) => pool.query(text, params),
+  end: () => pool.end()
+}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
+import db from '../db.js'
 
 class AuthService {
   constructor() {
@@ -30,44 +31,35 @@ class AuthService {
   verifyToken(token) {
     try {
       return jwt.verify(token, this.jwtSecret)
-    } catch (error) {
+    } catch {
       return null
     }
   }
 
-  // Mock user storage - in production, use a real database
-  users = new Map()
-
   async createUser({ email, password, name }) {
-    // Check if user exists
-    if (this.users.has(email)) {
+    const existing = await db.query('SELECT id FROM users WHERE email = $1', [email])
+    if (existing.rows.length > 0) {
       throw new Error('User already exists')
     }
 
     const hashedPassword = await this.hashPassword(password)
-    const user = {
-      id: Date.now().toString(),
-      email,
-      name,
-      password: hashedPassword,
-      createdAt: new Date(),
-      subscription: 'free',
-      videosCreated: 0,
-      monthlyLimit: 3
-    }
+    const result = await db.query(
+      `INSERT INTO users (email, name, password, created_at, subscription, videos_created, monthly_limit)
+       VALUES ($1, $2, $3, NOW(), 'free', 0, 3)
+       RETURNING id, email, name, created_at AS "createdAt", subscription, videos_created AS "videosCreated", monthly_limit AS "monthlyLimit"`,
+      [email, name, hashedPassword]
+    )
 
-    this.users.set(email, user)
-    
-    // Return user without password
-    const { password: _, ...userWithoutPassword } = user
+    const user = result.rows[0]
     return {
-      user: userWithoutPassword,
+      user,
       token: this.generateToken(user.id, user.email)
     }
   }
 
   async loginUser({ email, password }) {
-    const user = this.users.get(email)
+    const result = await db.query('SELECT * FROM users WHERE email = $1', [email])
+    const user = result.rows[0]
     if (!user) {
       throw new Error('Invalid credentials')
     }
@@ -77,8 +69,16 @@ class AuthService {
       throw new Error('Invalid credentials')
     }
 
-    // Return user without password
-    const { password: _, ...userWithoutPassword } = user
+    const userWithoutPassword = {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      createdAt: user.created_at,
+      subscription: user.subscription,
+      videosCreated: user.videos_created,
+      monthlyLimit: user.monthly_limit
+    }
+
     return {
       user: userWithoutPassword,
       token: this.generateToken(user.id, user.email)
@@ -86,43 +86,36 @@ class AuthService {
   }
 
   async getUserById(userId) {
-    for (const user of this.users.values()) {
-      if (user.id === userId) {
-        const { password: _, ...userWithoutPassword } = user
-        return userWithoutPassword
-      }
-    }
-    return null
+    const result = await db.query(
+      `SELECT id, email, name, created_at AS "createdAt", subscription, videos_created AS "videosCreated", monthly_limit AS "monthlyLimit"
+       FROM users WHERE id = $1`,
+      [userId]
+    )
+    return result.rows[0] || null
   }
 
   async updateUserSubscription(userId, subscription) {
-    for (const [email, user] of this.users.entries()) {
-      if (user.id === userId) {
-        const updatedUser = {
-          ...user,
-          subscription,
-          monthlyLimit: subscription === 'pro' ? -1 : subscription === 'business' ? -1 : 3
-        }
-        this.users.set(email, updatedUser)
-        const { password: _, ...userWithoutPassword } = updatedUser
-        return userWithoutPassword
-      }
+    const limit = subscription === 'pro' || subscription === 'business' ? -1 : 3
+    const result = await db.query(
+      `UPDATE users SET subscription = $2, monthly_limit = $3 WHERE id = $1
+       RETURNING id, email, name, created_at AS "createdAt", subscription, videos_created AS "videosCreated", monthly_limit AS "monthlyLimit"`,
+      [userId, subscription, limit]
+    )
+    if (result.rows.length === 0) {
+      throw new Error('User not found')
     }
-    throw new Error('User not found')
+    return result.rows[0]
   }
 
   async incrementVideoCount(userId) {
-    for (const [email, user] of this.users.entries()) {
-      if (user.id === userId) {
-        const updatedUser = {
-          ...user,
-          videosCreated: user.videosCreated + 1
-        }
-        this.users.set(email, updatedUser)
-        return updatedUser.videosCreated
-      }
+    const result = await db.query(
+      `UPDATE users SET videos_created = videos_created + 1 WHERE id = $1 RETURNING videos_created`,
+      [userId]
+    )
+    if (result.rows.length === 0) {
+      throw new Error('User not found')
     }
-    throw new Error('User not found')
+    return result.rows[0].videos_created
   }
 
   async checkVideoLimit(userId) {
@@ -137,7 +130,7 @@ class AuthService {
 
     const allowed = user.videosCreated < user.monthlyLimit
     const remaining = Math.max(0, user.monthlyLimit - user.videosCreated)
-    
+
     return { allowed, remaining }
   }
 }


### PR DESCRIPTION
## Summary
- replace in-memory auth store with PostgreSQL-backed persistence layer
- add migration script and user table creation
- document database setup and migrations

## Testing
- `npm run lint` *(fails: 'no-unused-vars' etc.)*
- `npm test` *(fails: The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables.)*

------
https://chatgpt.com/codex/tasks/task_b_688e4a9c50a08325a2d5778e1112d803