### PR TITLE
feat: support optional openai organization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ GEMINI_API_KEY=your_google_ai_studio_api_key_here
 GOOGLE_AI_API_KEY=your_google_ai_studio_api_key_here
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
 
+# OpenAI (optional)
+OPENAI_API_KEY=your_openai_api_key_here
+# Include if you need to scope requests to a specific organization
+OPENAI_ORG_ID=your_openai_org_id
+
 # Stock Media APIs
 PEXELS_API_KEY=your_pexels_api_key_here
 UNSPLASH_ACCESS_KEY=your_unsplash_access_key_here

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ npm run preview
 
 See `.env.example` for all available configuration options:
 
+- `OPENAI_API_KEY` - For OpenAI script generation (optional)
+- `OPENAI_ORG_ID` - OpenAI organization ID (optional)
 - `GOOGLE_AI_API_KEY` - For script generation
 - `ELEVENLABS_API_KEY` - For voice synthesis (optional)
 - `PEXELS_API_KEY` - For stock footage (optional)

--- a/docs/AI_INTEGRATIONS_GUIDE.md
+++ b/docs/AI_INTEGRATIONS_GUIDE.md
@@ -7,7 +7,7 @@ This document details all AI service integrations in the AI Video Creator platfo
 
 ### Primary: OpenAI GPT-4 Turbo
 - **Model**: `gpt-4-turbo-preview` (ready to switch to `o3` when available)
-- **Organization ID**: `org-kMMJiRlBzjmaoZSsnapWMOrx`
+- **Organization ID**: Configurable via `OPENAI_ORG_ID` (optional)
 - **Features**:
   - JSON structured output
   - Social media optimization
@@ -72,7 +72,8 @@ This document details all AI service integrations in the AI Video Creator platfo
 ```javascript
 headers: {
   'Authorization': `Bearer ${OPENAI_API_KEY}`,
-  'OpenAI-Organization': 'org-kMMJiRlBzjmaoZSsnapWMOrx'
+  // Include only if OPENAI_ORG_ID is set
+  ...(OPENAI_ORG_ID && { 'OpenAI-Organization': OPENAI_ORG_ID })
 }
 ```
 
@@ -154,6 +155,7 @@ All services have fallback strategies:
 ```bash
 # OpenAI
 OPENAI_API_KEY=sk-proj-...
+# Optional: scope requests to a specific organization
 OPENAI_ORG_ID=org-kMMJiRlBzjmaoZSsnapWMOrx
 
 # Google AI

--- a/src/services/scriptGenerator.js
+++ b/src/services/scriptGenerator.js
@@ -4,6 +4,7 @@ class ScriptGenerator {
   constructor() {
     // Try OpenAI first
     this.openaiKey = process.env.OPENAI_API_KEY
+    this.openaiOrgId = process.env.OPENAI_ORG_ID
     this.googleKey = process.env.GOOGLE_AI_API_KEY || process.env.GEMINI_API_KEY
     
     if (!this.openaiKey && !this.googleKey) {
@@ -97,13 +98,17 @@ Format as JSON with detailed scene breakdown:
     // Try OpenAI first (using GPT-4 until O3 is available)
     if (this.openaiKey) {
       try {
+        const headers = {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.openaiKey}`
+        }
+        if (this.openaiOrgId) {
+          headers['OpenAI-Organization'] = this.openaiOrgId
+        }
+
         const response = await fetch('https://api.openai.com/v1/chat/completions', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${this.openaiKey}`,
-            'OpenAI-Organization': 'org-kMMJiRlBzjmaoZSsnapWMOrx'
-          },
+          headers,
           body: JSON.stringify({
             // Note: Change to 'o3' when OpenAI releases the model
             // Currently using GPT-4 Turbo which is the most advanced available model


### PR DESCRIPTION
## Summary
- read optional OPENAI_ORG_ID env var for script generator
- include OpenAI-Organization header only when OPENAI_ORG_ID is set
- document OPENAI_ORG_ID in docs and example env file

## Testing
- `npm run lint` *(fails: 'error' is defined but never used, etc.)*
- `npm test` *(fails: module factory of jest.mock not allowed to reference out-of-scope variables)*

------
https://chatgpt.com/codex/tasks/task_b_688e4a9db7988325a1581749a5af0ecc