### PR TITLE
feat: add PostgreSQL session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ See `.env.example` for all available configuration options:
 - `PEXELS_API_KEY` - For stock footage (optional)
 - `VITE_API_URL` - Backend API URL
 
+## 🗃️ Session Storage
+
+Server sessions are stored in PostgreSQL using `connect-pg-simple`. Set
+`DATABASE_URL` in your environment to point at your Postgres instance. The
+session table is created automatically on startup, or you can create it
+manually using the SQL in [`docs/SESSION_TABLE_SETUP.md`](docs/SESSION_TABLE_SETUP.md).
+
 ## 🎨 UI/UX Features
 
 - **Dark Glassmorphic Design**: Modern, premium aesthetic

--- a/docs/SESSION_TABLE_SETUP.md
+++ b/docs/SESSION_TABLE_SETUP.md
@@ -1,0 +1,26 @@
+# PostgreSQL Session Table
+
+The server stores login sessions in PostgreSQL using [`connect-pg-simple`](https://github.com/voxpelli/node-connect-pg-simple).
+The table is created automatically on startup via `createTableIfMissing: true`, but you can also create it manually.
+
+## Manual creation
+
+Run the following SQL against your database:
+
+```sql
+CREATE TABLE IF NOT EXISTS "session" (
+  "sid" varchar NOT NULL PRIMARY KEY,
+  "sess" json NOT NULL,
+  "expire" timestamp(6) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_session_expire" ON "session" ("expire");
+```
+
+Or execute the SQL bundled with the package:
+
+```bash
+psql $DATABASE_URL -f node_modules/connect-pg-simple/table.sql
+```
+
+Ensure the `DATABASE_URL` environment variable points to your PostgreSQL instance.

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import dotenv from 'dotenv'
 import session from 'express-session'
+import connectPgSimple from 'connect-pg-simple'
 import ScriptGenerator from './src/services/scriptGenerator.js'
 import VoiceGenerator from './src/services/voiceGenerator.js'
 import MediaService from './src/services/mediaService.js'
@@ -14,6 +15,8 @@ dotenv.config()
 
 const app = express()
 const PORT = process.env.BACKEND_PORT || process.env.PORT || 4444
+
+const pgSession = connectPgSimple(session)
 
 // Initialize services
 const scriptGenerator = new ScriptGenerator()
@@ -31,6 +34,10 @@ app.use(express.json())
 
 // Session configuration
 app.use(session({
+  store: new pgSession({
+    conString: process.env.DATABASE_URL,
+    createTableIfMissing: true
+  }),
   secret: process.env.SESSION_SECRET || 'your-session-secret-change-in-production',
   resave: false,
   saveUninitialized: false,


### PR DESCRIPTION
## Summary
- use `connect-pg-simple` to persist express sessions in PostgreSQL
- document session storage setup and provide session table SQL

## Testing
- `npm run lint` *(fails: 158 problems)*
- `npm test` *(fails: 4 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_b_688e4a7420508325893a0f9210a6746e