### PR TITLE
feat: require session secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npm run preview
 
 See `.env.example` for all available configuration options:
 
+- `SESSION_SECRET` - Secret key for session cookies (required)
 - `OPENAI_API_KEY` - For OpenAI script generation (optional)
 - `OPENAI_ORG_ID` - OpenAI organization ID (optional)
 - `GOOGLE_AI_API_KEY` - For script generation

--- a/docs/AI_INTEGRATIONS_GUIDE.md
+++ b/docs/AI_INTEGRATIONS_GUIDE.md
@@ -153,6 +153,9 @@ All services have fallback strategies:
 ## 10. Environment Variables
 
 ```bash
+# Required for session management
+SESSION_SECRET=your_session_secret
+
 # OpenAI
 OPENAI_API_KEY=sk-proj-...
 # Optional: scope requests to a specific organization

--- a/docs/guides/DEPLOYMENT_GUIDE.md
+++ b/docs/guides/DEPLOYMENT_GUIDE.md
@@ -99,6 +99,8 @@ git push -u origin main
 Add these in Vercel dashboard → Settings → Environment Variables:
 ```
 NODE_ENV=production
+# Required for session encryption
+SESSION_SECRET=your_session_secret
 # Add any API keys here
 ```
 

--- a/docs/guides/SOCIAL_AI_PRO_SETUP.md
+++ b/docs/guides/SOCIAL_AI_PRO_SETUP.md
@@ -76,6 +76,9 @@ Add these in Vercel Dashboard → Settings → Environment Variables:
 VITE_API_URL=https://social-ai.pro
 NODE_ENV=production
 
+# Required for session encryption
+SESSION_SECRET=your_session_secret
+
 # Add your API keys (when ready)
 GOOGLE_AI_API_KEY=your_key_here
 ELEVENLABS_API_KEY=your_key_here

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -85,6 +85,7 @@ describe('ScriptGenerator', () => {
 process.env = {
   ...process.env,
   NODE_ENV: 'test',
+  SESSION_SECRET: 'test-secret',
   VITE_API_URL: 'http://localhost:3000'
 }
 ```

--- a/server.js
+++ b/server.js
@@ -30,6 +30,10 @@ import {
 
 dotenv.config()
 
+if (!process.env.SESSION_SECRET) {
+  throw new Error('SESSION_SECRET environment variable is required')
+}
+
 const app = express()
 const PORT = process.env.BACKEND_PORT || process.env.PORT || 4444
 
@@ -55,7 +59,7 @@ app.use(session({
     conString: process.env.DATABASE_URL,
     createTableIfMissing: true
   }),
-  secret: process.env.SESSION_SECRET || 'your-session-secret-change-in-production',
+  secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
   cookie: {


### PR DESCRIPTION
## Summary
- require SESSION_SECRET at startup and remove fallback secret
- document SESSION_SECRET as required in README and guides

## Testing
- `SESSION_SECRET=test-secret npm test` (fails: Cannot find module '../components/VoiceSelector'...)
- `SESSION_SECRET=test-secret npm run lint` (fails: 169 problems)

------
https://chatgpt.com/codex/tasks/task_b_688e60143be88325ad75bcb599ab3f6b