### PR TITLE
Enable App component tests and mock browser APIs

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -4,14 +4,13 @@ import App from '../App'
 // Mock fetch
 global.fetch = jest.fn()
 
-// Mock VoiceSelector to avoid complex dependencies in tests
-jest.mock('../components/VoiceSelector', () => {
+// Mock VoiceSelection to avoid complex dependencies in tests
+jest.mock('../components/VoiceSelection', () => {
   const React = require('react')
   return () => React.createElement('div', { 'data-testid': 'voice-selector' })
 })
 
-// Skipping these tests as the App component relies on complex browser APIs
-describe.skip('App Component', () => {
+describe('App Component', () => {
   beforeEach(() => {
     fetch.mockClear()
   })
@@ -146,14 +145,18 @@ describe.skip('App Component', () => {
       expect(screen.getByText('Platforms')).toBeInTheDocument()
     })
     
-    const tiktokButton = screen.getAllByText(/TikTok|Tik/i)[0]
-    
+    const getTiktokButton = () => screen.getByRole('button', { name: /TikTok|Tik/i })
+
     // Click to select
-    fireEvent.click(tiktokButton)
-    expect(tiktokButton.closest('button')).toHaveClass('border-white/30')
-    
+    fireEvent.click(getTiktokButton())
+    await waitFor(() =>
+      expect(getTiktokButton()).toHaveClass('border-white/30')
+    )
+
     // Click to deselect
-    fireEvent.click(tiktokButton)
-    expect(tiktokButton.closest('button')).not.toHaveClass('border-white/30')
+    fireEvent.click(getTiktokButton())
+    await waitFor(() =>
+      expect(getTiktokButton()).not.toHaveClass('border-white/30')
+    )
   })
 })

--- a/src/__tests__/api/server.test.js
+++ b/src/__tests__/api/server.test.js
@@ -41,6 +41,20 @@ jest.mock('../../services/mediaService.js', () => {
   }))
 })
 
+jest.mock('../../services/authService.js', () => {
+  return jest.fn().mockImplementation(() => ({
+    createUser: jest.fn().mockResolvedValue({
+      user: { id: 1, email: 'test@example.com', name: 'Tester' },
+      token: 'mock-token'
+    }),
+    loginUser: jest.fn().mockResolvedValue({
+      user: { id: 1, email: 'test@example.com', name: 'Tester' },
+      token: 'mock-token'
+    }),
+    getUserById: jest.fn()
+  }))
+})
+
 describe('API Endpoints', () => {
   let app
 


### PR DESCRIPTION
## Summary
- Reactivate `App` component tests and mock `VoiceSelection`
- Broaden JSDOM test setup with `scrollIntoView` and universal framer-motion proxy
- Stub `AuthService` in API tests for reliable auth flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688e6016052c832584a36f305c5c5592