### PR TITLE
Validate DATABASE_URL before initializing PostgreSQL pool

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -4,8 +4,8 @@ import App from '../App'
 // Mock fetch
 global.fetch = jest.fn()
 
-// Mock VoiceSelector to avoid complex dependencies in tests
-jest.mock('../components/VoiceSelector', () => {
+// Mock VoiceSelection to avoid complex dependencies in tests
+jest.mock('../components/VoiceSelection.jsx', () => {
   const React = require('react')
   return () => React.createElement('div', { 'data-testid': 'voice-selector' })
 })

--- a/src/__tests__/api/server.test.js
+++ b/src/__tests__/api/server.test.js
@@ -41,13 +41,76 @@ jest.mock('../../services/mediaService.js', () => {
   }))
 })
 
+jest.mock('../../services/authService.js', () => {
+  const users = new Map()
+  return jest.fn().mockImplementation(() => ({
+    createUser: jest.fn(async ({ email, password, name }) => {
+      if (users.has(email)) {
+        throw new Error('User already exists')
+      }
+      const user = {
+        id: users.size + 1,
+        email,
+        name,
+        password,
+        createdAt: new Date(),
+        subscription: 'free',
+        videosCreated: 0,
+        monthlyLimit: 3
+      }
+      users.set(email, user)
+      const { password: _p, ...userWithoutPassword } = user
+      return { user: userWithoutPassword, token: 'token-' + user.id }
+    }),
+    loginUser: jest.fn(async ({ email, password }) => {
+      const user = users.get(email)
+      if (!user || user.password !== password) {
+        throw new Error('Invalid credentials')
+      }
+      const { password: _p, ...userWithoutPassword } = user
+      return { user: userWithoutPassword, token: 'token-' + user.id }
+    }),
+    getUserById: jest.fn(async (id) => {
+      for (const user of users.values()) {
+        if (user.id === id) {
+          const { password: _p, ...userWithoutPassword } = user
+          return userWithoutPassword
+        }
+      }
+      return null
+    }),
+    incrementVideoCount: jest.fn(async (id) => {
+      for (const user of users.values()) {
+        if (user.id === id) {
+          user.videosCreated += 1
+          return user.videosCreated
+        }
+      }
+      throw new Error('User not found')
+    }),
+    checkVideoLimit: jest.fn(async (id) => {
+      for (const user of users.values()) {
+        if (user.id === id) {
+          const allowed = user.subscription !== 'free' ? true : user.videosCreated < user.monthlyLimit
+          const remaining = user.subscription !== 'free' ? -1 : Math.max(0, user.monthlyLimit - user.videosCreated)
+          return { allowed, remaining }
+        }
+      }
+      throw new Error('User not found')
+    }),
+    verifyToken: jest.fn(() => ({ userId: 1, email: 'test@example.com' }))
+  }))
+})
+
 describe('API Endpoints', () => {
   let app
 
   beforeEach(async () => {
     // Clear module cache to get fresh instance
     jest.resetModules()
-    
+    // Provide a dummy database URL for services that require it
+    process.env.DATABASE_URL = 'postgres://user:password@localhost:5432/testdb'
+
     // Import server after mocks are set up
     const serverModule = await import('../../../server.js')
     app = serverModule.default

--- a/src/__tests__/db.test.js
+++ b/src/__tests__/db.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals'
+
+describe('Database configuration', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV }
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  it('throws an error when DATABASE_URL is missing', async () => {
+    delete process.env.DATABASE_URL
+    await expect(import('../db.js')).rejects.toThrow('DATABASE_URL environment variable is required')
+  })
+
+  it('throws an error when DATABASE_URL is malformed', async () => {
+    process.env.DATABASE_URL = 'not-a-valid-url'
+    await expect(import('../db.js')).rejects.toThrow(/Invalid DATABASE_URL/)
+  })
+})

--- a/src/db.js
+++ b/src/db.js
@@ -2,8 +2,21 @@ import pkg from 'pg'
 
 const { Pool } = pkg
 
+const connectionString = process.env.DATABASE_URL
+
+if (!connectionString) {
+  throw new Error('DATABASE_URL environment variable is required')
+}
+
+try {
+  // Ensure the connection string is a valid URL
+  new URL(connectionString)
+} catch (error) {
+  throw new Error(`Invalid DATABASE_URL: ${error.message}`)
+}
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
   ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined
 })
 


### PR DESCRIPTION
## Summary
- ensure `DATABASE_URL` exists and is a valid URL before creating the PostgreSQL pool
- add unit tests for missing or malformed `DATABASE_URL`
- mock auth service and supply dummy `DATABASE_URL` in API tests; fix voice selection mock path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688e6017449c8325b82d8ff80b57dd58